### PR TITLE
feat: resolve relative paths against cwd instead of buffer directory

### DIFF
--- a/lsp/filepaths_ls.lua
+++ b/lsp/filepaths_ls.lua
@@ -117,13 +117,13 @@ local function resolve_scan_dir(document_uri, dir_part)
         return nil
     end
 
-    local buf_dir = vim.fs.dirname(file)
-    if not buf_dir or buf_dir == '' then
+    local base_dir = vim.uv.cwd() or vim.fs.dirname(file)
+    if not base_dir or base_dir == '' then
         return nil
     end
 
     if dir_part == '' then
-        return buf_dir
+        return base_dir
     end
 
     local env_name, env_suffix = dir_part:match('^%$([%a_][%w_]*)/(.*)$')
@@ -142,7 +142,7 @@ local function resolve_scan_dir(document_uri, dir_part)
         return vim.fs.normalize(dir_part)
     end
 
-    return vim.fs.normalize(vim.fs.joinpath(buf_dir, dir_part))
+    return vim.fs.normalize(vim.fs.joinpath(base_dir, dir_part))
 end
 
 ---@param path string


### PR DESCRIPTION
## Summary

- Resolve relative file paths (`./`, `../`) against Neovim's `cwd` (`vim.uv.cwd()`) instead of the edited file's parent directory
- Respects `:cd`, `:lcd`, and `:tcd` so completions match the user's working directory
- Falls back to buffer directory if `cwd` is unavailable

## Motivation

When editing a file in a subdirectory, typing `./` currently completes relative to that file's location. This is unexpected when your Neovim `cwd` is the project root — you'd expect completions relative to where `:pwd` points.

## Test plan

- [ ] Open a file in a subdirectory, type `./` — completions should list files from `:pwd`, not the file's parent
- [ ] Use `:lcd /some/path` then type `./` — completions should reflect the new local cwd
- [ ] Absolute paths (`/`, `~/`, `$VAR/`) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)